### PR TITLE
[feat/breadCrumb]: breadcrum component added to content pages

### DIFF
--- a/src/app/(pages)/(public)/content/javascript/page.jsx
+++ b/src/app/(pages)/(public)/content/javascript/page.jsx
@@ -19,7 +19,7 @@ const Subject = () => {
   }
 
   return (
-    <section className="space-y-4 py-24">
+    <section className="space-y-4 py-10">
       <Heading>JavaScript</Heading>
       <SubTitle>Content</SubTitle>
       <ProgressBar progress={progress} />

--- a/src/app/(pages)/(public)/content/layout.jsx
+++ b/src/app/(pages)/(public)/content/layout.jsx
@@ -1,0 +1,15 @@
+import Breadcrumb from "@/components/Breadcrumb";
+
+export default function Layout({ children }) {
+  return (
+    <>
+      <Breadcrumb
+          homeElement={'Home'}
+          separator={<span> | </span>}
+          capitalizeLinks
+      />
+      
+      <main>{children}</main>
+    </>
+  )
+}

--- a/src/components/Breadcrumb.jsx
+++ b/src/components/Breadcrumb.jsx
@@ -1,0 +1,46 @@
+'use client'
+import React from 'react'
+import { usePathname } from 'next/navigation'
+import Link from 'next/link'
+
+const Breadcrumb = ({homeElement, separator, capitalizeLinks}) => {
+
+    const paths = usePathname()
+    const pathNames = paths.split('/').filter( path => path )
+
+    const formatLink = (link) => {
+        let formattedLink = link.replace(/-/g, ' ');
+
+        if (capitalizeLinks) {
+            formattedLink = formattedLink.charAt(0).toUpperCase() + formattedLink.slice(1);
+        }
+
+        return formattedLink;
+    }
+
+    return (
+        <div>
+            <ul className="flex flex-wrap pt-24 bg-transparent">
+                <li className="hover:underline mx-2 font-bold"><Link href={'/'}>{homeElement}</Link></li>
+                {pathNames.length > 0 && separator}
+            {
+                pathNames.map( (link, index) => {
+                    let href = `/${pathNames.slice(0, index + 1).join('/')}`
+                    let itemClasses = paths === href ? "hover:underline mx-2 font-bold text-primary" : "hover:underline mx-2 font-bold"
+                    let itemLink = formatLink(link)
+                    return (
+                        <React.Fragment key={index}>
+                            <li className={itemClasses} >
+                                <Link href={href}>{itemLink}</Link>
+                            </li>
+                            {pathNames.length !== index + 1 && separator}
+                        </React.Fragment>
+                    )
+                })
+            }
+            </ul>
+        </div>
+    )
+}
+
+export default Breadcrumb


### PR DESCRIPTION
Hi guys! This is how breadcrumb looks like applied to content pages:

![image](https://github.com/user-attachments/assets/abdc08cc-8562-4b3a-8b0f-0dea14b96e56)

![image](https://github.com/user-attachments/assets/e71d00f8-4682-43a1-8486-7c12e1cae2ea)
